### PR TITLE
フィルターをURLに反映させて、ブックマーク可能にする

### DIFF
--- a/index.html
+++ b/index.html
@@ -732,6 +732,89 @@
 
         debugLog('スクリプト開始 - グローバル変数初期化完了');
 
+        // URLパラメータ操作関数
+        /**
+         * URLクエリパラメータを更新する
+         * @param {Object} params - 設定するパラメータ {key: value}
+         */
+        function updateURLParams(params) {
+            const url = new URL(window.location);
+            Object.keys(params).forEach(key => {
+                if (params[key] === null || params[key] === undefined) {
+                    url.searchParams.delete(key);
+                } else {
+                    url.searchParams.set(key, params[key]);
+                }
+            });
+            window.history.pushState({}, '', url);
+            debugLog(`URL更新: ${url.search}`);
+        }
+
+        /**
+         * URLクエリパラメータを取得する
+         * @param {string} key - 取得するパラメータ名
+         * @returns {string|null} パラメータ値
+         */
+        function getURLParam(key) {
+            const params = new URLSearchParams(window.location.search);
+            return params.get(key);
+        }
+
+        /**
+         * 全てのURLパラメータをクリアする
+         */
+        function clearURLParams() {
+            window.history.pushState({}, '', window.location.pathname);
+            debugLog('URLパラメータクリア');
+        }
+
+        /**
+         * URLパラメータからフィルター状態を復元する
+         */
+        function restoreFromURL() {
+            debugLog('URL状態復元開始');
+            try {
+                const filterType = getURLParam('filter');
+                const searchParam = getURLParam('search');
+
+                // 検索パラメータの復元
+                if (searchParam) {
+                    const searchInput = document.getElementById('wrestlerSearch');
+                    searchInput.value = searchParam;
+                    searchWrestlers();
+                    debugLog(`検索復元: ${searchParam}`);
+                }
+
+                // フィルターパラメータの復元
+                if (filterType === 'promotion') {
+                    const promotionName = getURLParam('promotion');
+                    if (promotionName) {
+                        // 団体名からインデックスを取得
+                        const promotionIndex = promotionNames.indexOf(promotionName);
+                        if (promotionIndex !== -1) {
+                            filterByPromotion(promotionName, promotionIndex + 1);
+                            debugLog(`団体フィルター復元: ${promotionName}`);
+                        }
+                    }
+                } else if (filterType === 'year') {
+                    const year = getURLParam('year');
+                    if (year) {
+                        const yearNum = parseInt(year);
+                        const yearRow = wrestlerData.find(row => row[0] === yearNum);
+                        if (yearRow) {
+                            showYearDetail(yearNum, yearRow);
+                            debugLog(`年度フィルター復元: ${year}`);
+                        }
+                    }
+                }
+
+                debugLog('URL状態復元完了');
+            } catch (error) {
+                debugLog(`URL状態復元エラー: ${error.message}`);
+                console.error(error);
+            }
+        }
+
         // デバッグ表示切り替え関数
         function toggleDebug() {
             debugVisible = !debugVisible;
@@ -2163,14 +2246,14 @@
             try {
                 // 検索中の場合は検索結果から、そうでなければ全データからフィルター
                 const sourceData = isSearching ? getCurrentFilteredData() : wrestlerData;
-                
+
                 const filteredResults = sourceData.filter(row => {
                     const wrestlers = row[promotionIndex];
                     return wrestlers && wrestlers.trim();
                 });
-                
+
                 debugLog(`フィルター結果: ${filteredResults.length}行`);
-                
+
                 currentFilter = {
                     type: 'promotion',
                     value: promotionName,
@@ -2178,7 +2261,13 @@
                     index: promotionIndex
                 };
                 isFiltered = true;
-                
+
+                // URLパラメータを更新
+                updateURLParams({
+                    filter: 'promotion',
+                    promotion: promotionName
+                });
+
                 showControls();
                 showPromotionDetail(promotionName, filteredResults, promotionIndex);
             } catch (error) {
@@ -2247,10 +2336,16 @@
                 }
                 
                 debugLog(`年詳細: ${promotions.length}団体に選手在籍`);
-                
+
                 currentFilter = {type: 'year', value: year, data: promotions};
                 isFiltered = true;
-                
+
+                // URLパラメータを更新
+                updateURLParams({
+                    filter: 'year',
+                    year: year
+                });
+
                 showControls();
                 showYearDetailView(year, promotions);
             } catch (error) {
@@ -2353,11 +2448,18 @@
             try {
                 currentFilter = null;
                 isFiltered = false;
-                
+
+                // URLパラメータをクリア（検索パラメータは保持）
+                const searchParam = getURLParam('search');
+                clearURLParams();
+                if (searchParam) {
+                    updateURLParams({ search: searchParam });
+                }
+
                 document.getElementById('controls').style.display = 'none';
                 document.getElementById('yearDetailView').style.display = 'none';
                 document.getElementById('tableContainer').style.display = 'block';
-                
+
                 // 検索中の場合は検索結果を再表示
                 if (isSearching) {
                     searchWrestlers(); // 検索結果を再表示
@@ -2385,6 +2487,10 @@
                 // 検索語が空の場合、全データを表示
                 isSearching = false;
                 originalData = null;
+
+                // URLから検索パラメータを削除
+                updateURLParams({ search: null });
+
                 resetFilter();
                 renderTable(wrestlerData);
                 updatePromotionHeaders();
@@ -2442,12 +2548,15 @@
             }).filter(row => row !== null);
             
             debugLog(`検索結果: ${filteredData.length}行がマッチ`);
-            
+
+            // URLパラメータを更新
+            updateURLParams({ search: searchTerm });
+
             // 検索結果を表示
             renderTable(filteredData);
             updateSearchResultHeaders(filteredData);
             calculateSearchResultWrestlers(filteredData);
-            
+
             // フィルターやその他の表示をリセット
             if (isFiltered) {
                 currentFilter = null;
@@ -2681,24 +2790,27 @@
             try {
                 const searchInput = document.getElementById('wrestlerSearch');
                 searchInput.value = '';
-                
+
                 isSearching = false;
                 originalData = null;
-                
+
+                // URLから検索パラメータを削除
+                updateURLParams({ search: null });
+
                 resetFilter();
                 renderTable(wrestlerData);
                 updatePromotionHeaders();
                 calculateTotalWrestlers();
-                
+
                 // ラベルを元に戻す
                 document.getElementById('totalWrestlersLabel').textContent = '総現役選手数';
-                
+
                 // 全ての列を表示状態に戻す
                 showAllColumns();
-                
+
                 // 列幅をリセット
                 resetColumnWidths();
-                
+
                 debugLog('検索クリア完了');
             } catch (error) {
                 debugLog(`検索クリアエラー: ${error.message}`);
@@ -2715,6 +2827,10 @@
                 debugLog('選手数計算完了');
                 updatePromotionHeaders();
                 debugLog('団体ヘッダー更新完了');
+
+                // URLパラメータから状態を復元
+                restoreFromURL();
+
                 debugLog('初期化完了 - 全ての機能が利用可能です');
             } catch (error) {
                 debugLog(`初期化エラー: ${error.message}`);


### PR DESCRIPTION
## Summary
- URLパラメータでフィルター状態を管理し、ブックマーク可能にした
- ページ読み込み時にURLからフィルター状態を復元する機能を実装
- 団体フィルター、年度フィルター、選手検索すべてに対応

## 実装内容
- **URLパラメータ操作関数**: updateURLParams, getURLParam, clearURLParams
- **団体フィルター**: `?filter=promotion&promotion=団体名`
- **年度フィルター**: `?filter=year&year=年度`  
- **選手検索**: `?search=検索語`
- **状態復元**: restoreFromURL関数でページ読み込み時に自動復元

## Test plan
- [x] 団体をクリックしてURLが更新されることを確認
- [x] 年度をクリックしてURLが更新されることを確認
- [x] 選手名で検索してURLが更新されることを確認
- [x] URLを直接入力して該当のフィルター状態が復元されることを確認
- [x] ブックマークから開いて状態が復元されることを確認

fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)